### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,61 +2,6 @@ name: Build Swift-LLVM-Packages
 
 on: push
 
-jobs:
-  FourOH:
-    runs-on: macOS-latest
-    steps:
-      - name: Checkout legacy llvm
-        uses: actions/checkout@v2
-        with:
-          repository: apple/swift-llvm
-          ref: swift-4.0-branch
-      - name: Configure
-        run: cmake -Bbuild -DLLVM_TARGETS_TO_BUILD='X86;AArch64;ARM' -DLLVM_INCLUDE_TESTS=0 -DLLVM_INCLUDE_DOCS=0 -DLLVM_INCLUDE_EXAMPLES=0 -DLLVM_INCLUDE_GO_TESTS=0 -DLLVM_ENABLE_OCAMLDOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/install
-      - name: build
-        run: |
-          cmake --build build
-          cd build
-          make install
-      - name: package
-        uses: actions/upload-artifact@v2
-        with:
-          name: swift-llvm-40
-          path: |
-            build/install/**/*.a
-            build/install/**/cmake
-            build/install/include
-            build/install/**/llc
-            build/install/**/llvm-dis
-            build/install/**/llvm-config
-
-  FourOne:
-    runs-on: macOS-latest
-    steps:
-      - name: Checkout legacy llvm
-        uses: actions/checkout@v2
-        with:
-          repository: apple/swift-llvm
-          ref: swift-4.1-branch
-      - name: Configure
-        run: cmake -Bbuild -DLLVM_TARGETS_TO_BUILD='X86;AArch64;ARM' -DLLVM_INCLUDE_TESTS=0 -DLLVM_INCLUDE_DOCS=0 -DLLVM_INCLUDE_EXAMPLES=0 -DLLVM_INCLUDE_GO_TESTS=0 -DLLVM_ENABLE_OCAMLDOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/install
-      - name: build
-        run: |
-          cmake --build build
-          cd build
-          make install
-      - name: package
-        uses: actions/upload-artifact@v2
-        with:
-          name: swift-llvm-41
-          path: |
-            build/install/**/*.a
-            build/install/**/cmake
-            build/install/include
-            build/install/**/llc
-            build/install/**/llvm-dis
-            build/install/**/llvm-config
-
   FourTwo:
     runs-on: macOS-latest
     steps:
@@ -112,14 +57,14 @@ jobs:
             build/install/**/llvm-dis
             build/install/**/llvm-config
 
-  FiveOne:
+  FiveOneThree:
     runs-on: macOS-latest
     steps:
       - name: Checkout legacy llvm
         uses: actions/checkout@v2
         with:
           repository: apple/swift-llvm
-          ref: swift-5.1-branch
+          ref: swift-5.1.3-RELEASE
       - name: Configure
         run: cmake -Bbuild -DLLVM_TARGETS_TO_BUILD='X86;AArch64;ARM' -DLLVM_INCLUDE_TESTS=0 -DLLVM_INCLUDE_DOCS=0 -DLLVM_INCLUDE_EXAMPLES=0 -DLLVM_INCLUDE_GO_TESTS=0 -DLLVM_ENABLE_OCAMLDOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/install
       - name: build
@@ -130,7 +75,7 @@ jobs:
       - name: package
         uses: actions/upload-artifact@v2
         with:
-          name: swift-llvm-51
+          name: swift-llvm-513
           path: |
             build/install/**/*.a
             build/install/**/cmake
@@ -147,7 +92,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: apple/llvm-project
-          ref: swift/swift-5.2-branch
+          ref: swift-5.2.4-RELEASE
       - name: Configure
         run: cmake -Bbuild -DLLVM_TARGETS_TO_BUILD='X86;AArch64;ARM' -DLLVM_INCLUDE_TESTS=0 -DLLVM_INCLUDE_DOCS=0 -DLLVM_INCLUDE_EXAMPLES=0 -DLLVM_INCLUDE_GO_TESTS=0 -DLLVM_ENABLE_OCAMLDOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/install llvm
       - name: build
@@ -175,7 +120,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: apple/llvm-project
-          ref: swift/release/5.3
+          ref: swift-5.3-RELEASE
       - name: Configure
         run: cmake -Bbuild -DLLVM_TARGETS_TO_BUILD='X86;AArch64;ARM' -DLLVM_INCLUDE_TESTS=0 -DLLVM_INCLUDE_DOCS=0 -DLLVM_INCLUDE_EXAMPLES=0 -DLLVM_INCLUDE_GO_TESTS=0 -DLLVM_ENABLE_OCAMLDOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/install llvm
       - name: build
@@ -187,6 +132,34 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: swift-llvm-53
+          path: |
+            build/install/**/*.a
+            build/install/**/cmake
+            build/install/include
+            build/install/**/llc
+            build/install/**/llvm-dis
+            build/install/**/llvm-config
+
+
+  FiveThreeOne:
+    runs-on: macOS-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          repository: apple/llvm-project
+          ref: swift-5.3.1-RELEASE
+      - name: Configure
+        run: cmake -Bbuild -DLLVM_TARGETS_TO_BUILD='X86;AArch64;ARM' -DLLVM_INCLUDE_TESTS=0 -DLLVM_INCLUDE_DOCS=0 -DLLVM_INCLUDE_EXAMPLES=0 -DLLVM_INCLUDE_GO_TESTS=0 -DLLVM_ENABLE_OCAMLDOC=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/install llvm
+      - name: build
+        run: |
+          cmake --build build
+          cd build
+          make install
+      - name: package
+        uses: actions/upload-artifact@v2
+        with:
+          name: swift-llvm-531
           path: |
             build/install/**/*.a
             build/install/**/cmake


### PR DESCRIPTION
Swift 4.0 and 4.1 aren't needed any more. Updated reference for 5.2.4. Added 5.3.1.